### PR TITLE
Some AF for F1 are missing

### DIFF
--- a/src/genpinmap/genpinmap_arduino.py
+++ b/src/genpinmap/genpinmap_arduino.py
@@ -100,11 +100,11 @@ def get_gpio_af_numF1(xml, pintofind, iptofind):
                                 if iptofind in secondlevel:
                                     # m = IP node found
                                     #print (i, j,  m.attributes.items())
-                                    if m.hasChildNodes() == False:
-                                        mygpioaf = 'AFIO_NONE'
-                                    else:
-                                        for p in m.childNodes:
-                                            #p node 'RemapBlock'
+                                    for p in m.childNodes:
+                                        #p node 'RemapBlock'
+                                        if p.nodeType == Node.ELEMENT_NODE and p.hasChildNodes() == False:
+                                            mygpioaf += ' AFIO_NONE'
+                                        else:
                                             for s in p.childNodes:
                                                 if s.nodeType == Node.ELEMENT_NODE:
                                                     #s node 'Specific parameter'


### PR DESCRIPTION
Ex for F103C8 (Blue pill) there are 2 possibilities: 
For PA0:
```
        <PinSignal Name="TIM2_CH1">
            <RemapBlock Name="TIM2_REMAP0" DefaultRemap="true" />
            <RemapBlock Name="TIM2_REMAP2">
               <SpecificParameter Name="GPIO_AF">
                   <PossibleValue>__HAL_AFIO_REMAP_TIM2_PARTIAL_2</PossibleValue>
               </SpecificParameter>
            </RemapBlock>
        </PinSignal>
```
