### PR TITLE
run_arduino_sh: Add log command, some improvements

### DIFF
--- a/run_arduino_gen.sh
+++ b/run_arduino_gen.sh
@@ -111,7 +111,7 @@ generate_packaged_script() {
   fi
   echo "'" >> $output_script
   tail -n +$(grep -n "%}" "$this_script" | cut -d: -f1 | head -n 1) $this_script >> $output_script
-  dos2unix $output_script
+  dos2unix $output_script 2> /dev/null
 }
 
 

--- a/run_arduino_gen.sh
+++ b/run_arduino_gen.sh
@@ -213,7 +213,10 @@ case "$1" in
     ;;
   send-file)
     autodetect_board
-    dd if="$2" of=$RPMSG_DIR
+    # Maximum buffer size at a time: 512 - 16 bytes
+    # Otherwise, it used to return error in earlier version of OpenSTLinux
+    # Reference: https://elixir.bootlin.com/linux/v5.5.6/source/drivers/rpmsg/virtio_rpmsg_bus.c#L581
+    dd if="$2" bs=496 of=$RPMSG_DIR
     ;;
   minicom)
     autodetect_board

--- a/run_arduino_gen.sh
+++ b/run_arduino_gen.sh
@@ -204,7 +204,7 @@ case "$1" in
     ;;
   monitor)
     autodetect_board
-    stty igncr onlcr -echo -F $RPMSG_DIR
+    stty raw -echo -echoe -echok -F $RPMSG_DIR
     cat $RPMSG_DIR
     ;;
   send-msg)

--- a/run_arduino_gen.sh
+++ b/run_arduino_gen.sh
@@ -167,7 +167,7 @@ try_send() {
   # Linux host must send any dummy data first to finish initialization of rpmsg
   # on the coprocessor side. This message should be discarded.
   # See: https://github.com/OpenAMP/open-amp/issues/182
-  echo "DUMMY" >$RPMSG_DIR
+  echo -n "DUMMY" >$RPMSG_DIR
   echo "Virtual serial $RPMSG_DIR connection established."
 }
 

--- a/run_arduino_gen.sh
+++ b/run_arduino_gen.sh
@@ -218,6 +218,9 @@ case "$1" in
     # Reference: https://elixir.bootlin.com/linux/v5.5.6/source/drivers/rpmsg/virtio_rpmsg_bus.c#L581
     dd if="$2" bs=496 of=$RPMSG_DIR
     ;;
+  log)
+    cat /sys/kernel/debug/remoteproc/remoteproc0/trace0
+    ;;
   minicom)
     autodetect_board
     TERM=xterm minicom -D $RPMSG_DIR
@@ -234,7 +237,8 @@ case "$1" in
   *)
     echo "Usage: $0 [start|stop|restart]"
     echo "       $0 [install|uninstall]"
-    echo "       $0 [monitor|send-msg|send-file|minicom]"
+    echo "       $0 [monitor|minicom|log]"
+    echo "       $0 [send-msg|send-file] ..."
     echo "       $0 [generate]"
     echo ""
     echo "$0 is a helper script that helps managing an Arduino binary"
@@ -268,6 +272,9 @@ case "$1" in
     echo ""
     echo "$0 minicom"
     echo "    Launch minicom interactive serial communication program."
+    echo ""
+    echo "$0 log"
+    echo "    Print debugging log in OpenAMP trace buffer."
     echo ""
     echo "$0 stop"
     echo "    Stop the coprocessor."


### PR DESCRIPTION
Related: https://github.com/stm32duino/Arduino_Core_STM32/pull/766

I added log command for newly-introduced core_debug logging feature. I also include some improvements of existing commands, as the git commit messages explains.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stm32duino/arduino_tools/55)
<!-- Reviewable:end -->
