### PR TITLE
[STM32CubeProg] Add offset option for upload

### DIFF
--- a/win/stm32CubeProg.bat
+++ b/win/stm32CubeProg.bat
@@ -66,9 +66,24 @@ goto :opt
 :opt
 shift
 shift
+goto :optloop
+
+:optloop
+if "%~1"=="-o" goto :offset
 if "%~1"=="" goto :prog
-set OPTS=%1 %2 %3 %4 %5 %6 %7 %8 %9
-goto :prog
+set OPTS=%OPTS% %1
+shift
+goto :optloop
+
+:offset
+if "%~2"=="" set ERROR=2 & goto :usage
+set OFFSET=%~2
+SET /A ADDOFF=%ADDRESS%+%OFFSET%
+cmd /C exit %ADDOFF%
+set "ADDRESS=0x%=ExitCode%"
+shift
+shift
+goto :optloop
 
 :prog
 %STM32CP_CLI% -c port=%PORT% %MODE% %ERASE% -q -d %FILEPATH% %ADDRESS% %OPTS%
@@ -94,4 +109,5 @@ exit 0
   echo   Ex: -g: Run the code at the specified address
   echo       -rst: Reset system
   echo       -s: start automatically (optional)
+  echo       -o: offset address (optional). Ex: -o 0x2000
   exit %ERROR%


### PR DESCRIPTION
By issue #57 and using the @GIPdA idea.

Add an option command to offset the upload address. `Ex: -o 0x5000`

The already implemented parameter `build.flash_offset` can be used to upload on the 0x08005000 using the stm32CubeProg tool like this board configuration.

```
GenF1.menu.upload_method.serialMethod2=STM32CubeProgrammer (Serial) - Bootloader
GenF1.menu.upload_method.serialMethod2.upload.protocol=1
GenF1.menu.upload_method.serialMethod2.upload.options={serial.port.file} -s
GenF1.menu.upload_method.serialMethod2.upload.tool=stm32CubeProg
GenF1.menu.upload_method.serialMethod2.build.flash_offset=0x5000
GenF1.menu.upload_method.serialMethod2.build.bootloader_flags=-DVECT_TAB_OFFSET={build.flash_offset}
```

It needs to change the `platform.txt` on the `Arduino_Core_STM32` and add `-o {build.flash_offset}` on the upload pattern.

```
tools.stm32CubeProg.upload.pattern="{path}/{cmd}" {upload.protocol} "{build.path}/{build.project_name}.bin" {upload.options} -o {build.flash_offset}
```

This should make all the boards with `build.flash_offset` offset the upload when using the `stm32CubeProg`.

See yaa.






