### PR TITLE
[massStorageCopy] Handle short node name

### DIFF
--- a/linux/massStorageCopy.sh
+++ b/linux/massStorageCopy.sh
@@ -56,8 +56,16 @@ if [ ! -f "$bin_filepath" ]; then
   exit 2
 fi
 
+# Add short node name
+IFS=' ,\t' read -ra mnt_list <<< "$mountpoint_name"
+for mnt in "${mnt_list[@]}"; do
+  if [[ "$mnt" == "NODE_"* ]]; then
+    mountpoint_name="${mountpoint_name},${mnt//E_/_}"
+  fi
+done
+
 # Search the mountpoint
-IFS=',' read -ra mnt_list <<< "$mountpoint_name"
+IFS=' ,\t' read -ra mnt_list <<< "$mountpoint_name"
 for mnt in "${mnt_list[@]}"; do
   # mnt_path_list=(`cat /proc/mounts | cut -d' ' -f2 | sort -u | grep $mnt`)
   mnt_path_list=($(df -Hl | grep -v "Mounted on" | rev | cut -d' ' -f1 | rev | sort -u | grep "$mnt"))

--- a/macosx/massStorageCopy.sh
+++ b/macosx/massStorageCopy.sh
@@ -56,8 +56,16 @@ if [ ! -f "$bin_filepath" ]; then
   exit 2
 fi
 
+# Add short node name
+IFS=' ,\t' read -ra mnt_list <<< "$mountpoint_name"
+for mnt in "${mnt_list[@]}"; do
+  if [[ "$mnt" == "NODE_"* ]]; then
+    mountpoint_name="${mountpoint_name},${mnt//E_/_}"
+  fi
+done
+
 # Search the mountpoint
-IFS=',' read -ra mnt_list <<< "$mountpoint_name"
+IFS=' ,\t' read -ra mnt_list <<< "$mountpoint_name"
 for mnt in "${mnt_list[@]}"; do
   mnt_path_list=($(df -Hl | grep -v "Mounted on" | rev | cut -d' ' -f1 | rev | sort -u | grep "$mnt"))
   if [ ${#mnt_path_list[@]} -ne 0 ]; then

--- a/win/massStorageCopy.bat
+++ b/win/massStorageCopy.bat
@@ -1,17 +1,17 @@
-@ECHO off
+@echo off
 
-REM Exit codes for xcopy
-REM code | Description
-REM  0   | Files were copied without error.
-REM  1   | No files were found to copy.
-REM  2   | The user pressed CTRL+C to terminate xcopy.
-REM  4   | Initialization error occurred. There is not enough memory or disk space, or you entered an invalid drive name or invalid syntax on the command line.
-REM  5   | Disk write error occurred.
+rem Exit codes for xcopy
+rem code | Description
+rem  0   | Files were copied without error.
+rem  1   | No files were found to copy.
+rem  2   | The user pressed CTRL+C to terminate xcopy.
+rem  4   | Initialization error occurred. There is not enough memory or disk space, or you entered an invalid drive name or invalid syntax on the command line.
+rem  5   | Disk write error occurred.
 
-SET SOURCE=%2
-SET SRC_PARSE=%SOURCE:/=\%
-SET TARGET=%4
-SET TARGET=%TARGET:\=%
+set SOURCE=%2
+set SRC_PARSE=%SOURCE:/=\%
+set TARGET=%4
+set TARGET=%TARGET:\=%
 
 call :parse %TARGET%
 echo %TARGET% not found. Please ensure the device is correctly connected.
@@ -21,19 +21,29 @@ exit 7
 set list=%1
 set list=%list:"=%
 
-for /f "tokens=1* delims=," %%a in ("%list%") DO (
+for /f "tokens=1* delims=," %%a in ("%list%") do (
   if not "%%a" == "" call :sub %%a
+  if not "%%a" == "" call :nod %%a
   if not "%%b" == "" call :parse "%%b"
 )
 goto :eof
 
+rem Try with the short name NOD_XXX
+:nod
+  setlocal enabledelayedexpansion
+  echo.%~1|findstr /C:"NODE_" >nul 2>&1
+  if not errorlevel 1 (
+    set name=%~1
+    call :sub !name:E_=_!
+  )
+goto :eof
 
 :sub
 setlocal enabledelayedexpansion
 for /F "skip=1 tokens=*" %%a in ('WMIC LOGICALDISK where "volumename like '%~1'" get deviceid 2^>NUL') do if not defined id set id=%%a
-  call Set "deviceid=%%id: =%%"
+  call set "deviceid=%%id: =%%"
   if not "%deviceid%" == "" (
     XCOPY %SRC_PARSE% %deviceid% /Y /Q
-    if  !errorlevel! == 0 (echo Upload complete on %1 ^(%deviceid%^))   
+    if  !errorlevel! == 0 (echo Upload complete on %1 ^(%deviceid%^))
     exit !errorlevel!)
 goto :eof


### PR DESCRIPTION
Newest firmware shorten the node name:
`NODE_XXX` becomes `NOD_XXX`

To avoid updating each board definition in the boards.txt with both values, it is managed by the script.

