### PR TITLE
[maple_upload] Improve script on linux and macosx

### DIFF
--- a/linux/maple_upload.sh
+++ b/linux/maple_upload.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#set -e
+set -e
 
 if [ $# -lt 4 ]; then
   echo "Usage: $0 $# <dummy_port> <altID> <usbID> <binfile>" >&2
@@ -24,16 +24,42 @@ DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # This value is in milliseonds
 # You may need to tune this to your system
 # 750ms to 1500ms seems to work on my Mac
+# This is less critical now that we automatically retry dfu-util
 
-"${DIR}/upload-reset" "${dummy_port_fullpath}" 750
+if ! "${DIR}/upload-reset" "${dummy_port_fullpath}" 750
+then
+  echo "****************************************" >&2
+  echo "* Could not automatically reset device *" >&2
+  echo "* Please manually reset device!        *" >&2
+  echo "****************************************" >&2
+  sleep 2 # Wait for user to see message.
+fi
 
-"${DIR}/dfu-util.sh" -d "${usbID}" -a "${altID}" -D "${binfile}" ${dfuse_addr} -R
+COUNTER=10
+while "${DIR}/dfu-util.sh" -d "${usbID}" -a "${altID}" -D "${binfile}" ${dfuse_addr} -R ; ((ret=$?))
+do
+  if [ $ret -eq 74 ] && [ $((--COUNTER)) -gt 0 ]
+  then
+    # I/O error, probably because no DFU device was found
+    echo "Trying ${COUNTER} more time(s)" >&2
+    sleep 1
+  else
+    exit $ret
+  fi
+done
 
-echo -n Waiting for "${dummy_port_fullpath}" serial...
+echo -n "Waiting for ${dummy_port_fullpath} serial..." >&2
 
-COUNTER=0
-while [ ! -r "${dummy_port_fullpath}" ] && ((COUNTER++ < 40)); do
+COUNTER=40
+while [ ! -r "${dummy_port_fullpath}" ] && ((COUNTER--)); do
+  echo -n "." >&2
   sleep 0.1
 done
 
-echo Done
+if [ $COUNTER -eq -1 ]
+then
+  echo " Timed out." >&2
+  exit 1
+else
+  echo " Done." >&2
+fi

--- a/linux/maple_upload.sh
+++ b/linux/maple_upload.sh
@@ -26,8 +26,7 @@ DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # 750ms to 1500ms seems to work on my Mac
 # This is less critical now that we automatically retry dfu-util
 
-if ! "${DIR}/upload-reset" "${dummy_port_fullpath}" 750
-then
+if ! "${DIR}/upload-reset" "${dummy_port_fullpath}" 750; then
   echo "****************************************" >&2
   echo "* Could not automatically reset device *" >&2
   echo "* Please manually reset device!        *" >&2
@@ -36,10 +35,11 @@ then
 fi
 
 COUNTER=10
-while "${DIR}/dfu-util.sh" -d "${usbID}" -a "${altID}" -D "${binfile}" ${dfuse_addr} -R ; ((ret=$?))
+while
+  "${DIR}/dfu-util.sh" -d "${usbID}" -a "${altID}" -D "${binfile}" ${dfuse_addr} -R
+  ((ret = $?))
 do
-  if [ $ret -eq 74 ] && [ $((--COUNTER)) -gt 0 ]
-  then
+  if [ $ret -eq 74 ] && [ $((--COUNTER)) -gt 0 ]; then
     # I/O error, probably because no DFU device was found
     echo "Trying ${COUNTER} more time(s)" >&2
     sleep 1
@@ -56,8 +56,7 @@ while [ ! -r "${dummy_port_fullpath}" ] && ((COUNTER--)); do
   sleep 0.1
 done
 
-if [ $COUNTER -eq -1 ]
-then
+if [ $COUNTER -eq -1 ]; then
   echo " Timed out." >&2
   exit 1
 else

--- a/linux/maple_upload.sh
+++ b/linux/maple_upload.sh
@@ -34,7 +34,7 @@ if ! "${DIR}/upload-reset" "${dummy_port_fullpath}" 750; then
   sleep 2 # Wait for user to see message.
 fi
 
-COUNTER=10
+COUNTER=5
 while
   "${DIR}/dfu-util.sh" -d "${usbID}" -a "${altID}" -D "${binfile}" ${dfuse_addr} -R
   ((ret = $?))

--- a/macosx/dfu-util.sh
+++ b/macosx/dfu-util.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Get the directory where the script is running.
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+DFU_UTIL=${DIR}/dfu-util/dfu-util
+if [ ! -x "${DFU_UTIL}" ]; then
+  DFU_UTIL=/opt/local/bin/dfu-util
+fi
+
+# Not found!
+if [ ! -x "${DFU_UTIL}" ]; then
+  echo "$0: error: cannot find ${DFU_UTIL}" >&2
+  exit 2
+fi
+
+# Pass all parameters through
+"${DFU_UTIL}" "$@"

--- a/macosx/maple_upload.sh
+++ b/macosx/maple_upload.sh
@@ -40,18 +40,7 @@ else
   dfuse_addr=""
 fi
 
-#DFU_UTIL=/usr/local/bin/dfu-util
-DFU_UTIL=${DIR}/dfu-util/dfu-util
-if [ ! -x "${DFU_UTIL}" ]; then
-  DFU_UTIL=/opt/local/bin/dfu-util
-fi
-
-if [ ! -x ${DFU_UTIL} ]; then
-  echo "$0: error: cannot find ${DFU_UTIL}" >&2
-  exit 2
-fi
-
-${DFU_UTIL} -d "${usbID}" -a "${altID}" -D "${binfile}" -R ${dfuse_addr} -R
+"${DIR}/dfu-util.sh" -d "${usbID}" -a "${altID}" -D "${binfile}" -R ${dfuse_addr} -R
 
 echo -n Waiting for "${dummy_port_fullpath}" serial...
 

--- a/macosx/maple_upload.sh
+++ b/macosx/maple_upload.sh
@@ -26,8 +26,7 @@ DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # 750ms to 1500ms seems to work on my Mac
 # This is less critical now that we automatically retry dfu-util
 
-if ! "${DIR}/upload-reset" "${dummy_port_fullpath}" 750
-then
+if ! "${DIR}/upload-reset" "${dummy_port_fullpath}" 750; then
   echo "****************************************" >&2
   echo "* Could not automatically reset device *" >&2
   echo "* Please manually reset device!        *" >&2
@@ -36,10 +35,11 @@ then
 fi
 
 COUNTER=10
-while "${DIR}/dfu-util.sh" -d "${usbID}" -a "${altID}" -D "${binfile}" ${dfuse_addr} -R ; ((ret=$?))
+while
+  "${DIR}/dfu-util.sh" -d "${usbID}" -a "${altID}" -D "${binfile}" ${dfuse_addr} -R
+  ((ret = $?))
 do
-  if [ $ret -eq 74 ] && [ $((--COUNTER)) -gt 0 ]
-  then
+  if [ $ret -eq 74 ] && [ $((--COUNTER)) -gt 0 ]; then
     # I/O error, probably because no DFU device was found
     echo "Trying ${COUNTER} more time(s)" >&2
     sleep 1
@@ -56,8 +56,7 @@ while [ ! -r "${dummy_port_fullpath}" ] && ((COUNTER--)); do
   sleep 0.1
 done
 
-if [ $COUNTER -eq -1 ]
-then
+if [ $COUNTER -eq -1 ]; then
   echo " Timed out." >&2
   exit 1
 else

--- a/macosx/maple_upload.sh
+++ b/macosx/maple_upload.sh
@@ -6,47 +6,60 @@ if [ $# -lt 4 ]; then
   echo "Usage: $0 $# <dummy_port> <altID> <usbID> <binfile>" >&2
   exit 1
 fi
-altID=$2
-usbID=$3
-binfile=$4
+altID="$2"
+usbID="$3"
+binfile="$4"
 dummy_port_fullpath="/dev/$1"
-
-# Get the directory where the script is running.
-DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-
-# -----------------  Old code to reset the USB - which doesn't seem to work --------
-#
-#if we can find the Serial device try resetting it and then sleeping for 1 sec while the board reboots
-#if [ -e $dummy_port_fullpath ]; then
-#	echo "resetting " $dummy_port_fullpath
-#	stty -f $dummy_port_fullpath 1200
-#	sleep 1
-##	stty -f $dummy_port_fullpath 1200
-##	sleep 1
-#fi
-# ------------------  End of old code -----------------
-
-#  ----------------- IMPORTANT -----------------
-# The 2nd parameter to upload-reset is the delay after resetting before it exits
-# This value is in milliseonds
-# You may need to tune this to your system
-# 750ms to 1500ms seems to work on my Mac
-
-"${DIR}"/upload-reset "${dummy_port_fullpath}" 750
-
 if [ $# -eq 5 ]; then
   dfuse_addr="--dfuse-address $5"
 else
   dfuse_addr=""
 fi
 
-"${DIR}/dfu-util.sh" -d "${usbID}" -a "${altID}" -D "${binfile}" -R ${dfuse_addr} -R
+# Get the directory where the script is running.
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-echo -n Waiting for "${dummy_port_fullpath}" serial...
+#  ----------------- IMPORTANT -----------------
+# The 2nd parameter to upload-reset is the delay after resetting before it exits
+# This value is in milliseonds
+# You may need to tune this to your system
+# 750ms to 1500ms seems to work on my Mac
+# This is less critical now that we automatically retry dfu-util
 
-COUNTER=0
-while [ ! -c "${dummy_port_fullpath}" ] && ((COUNTER++ < 40)); do
+if ! "${DIR}/upload-reset" "${dummy_port_fullpath}" 750
+then
+  echo "****************************************" >&2
+  echo "* Could not automatically reset device *" >&2
+  echo "* Please manually reset device!        *" >&2
+  echo "****************************************" >&2
+  sleep 2 # Wait for user to see message.
+fi
+
+COUNTER=10
+while "${DIR}/dfu-util.sh" -d "${usbID}" -a "${altID}" -D "${binfile}" ${dfuse_addr} -R ; ((ret=$?))
+do
+  if [ $ret -eq 74 ] && [ $((--COUNTER)) -gt 0 ]
+  then
+    # I/O error, probably because no DFU device was found
+    echo "Trying ${COUNTER} more time(s)" >&2
+    sleep 1
+  else
+    exit $ret
+  fi
+done
+
+echo -n "Waiting for ${dummy_port_fullpath} serial..." >&2
+
+COUNTER=40
+while [ ! -r "${dummy_port_fullpath}" ] && ((COUNTER--)); do
+  echo -n "." >&2
   sleep 0.1
 done
 
-echo Done
+if [ $COUNTER -eq -1 ]
+then
+  echo " Timed out." >&2
+  exit 1
+else
+  echo " Done." >&2
+fi

--- a/macosx/maple_upload.sh
+++ b/macosx/maple_upload.sh
@@ -34,7 +34,7 @@ if ! "${DIR}/upload-reset" "${dummy_port_fullpath}" 750; then
   sleep 2 # Wait for user to see message.
 fi
 
-COUNTER=10
+COUNTER=5
 while
   "${DIR}/dfu-util.sh" -d "${usbID}" -a "${altID}" -D "${binfile}" ${dfuse_addr} -R
   ((ret = $?))


### PR DESCRIPTION
This makes it possible to recover if upload-reset isn't working, for example if a board is running a sketch without USB CDC enabled

Changes:
* Uncomment `set -e`
* Ask the user to manually reset their device if upload-reset fails
* Retry dfu-util if no device is found
* Print periods while waiting for serial port
* Exit with an error if script times out while waiting for serial port
* Send all messages to STDERR
