### PR TITLE
Fix Java PATH problem on Windows (Fix Issue #67)

### DIFF
--- a/win/maple_upload.bat
+++ b/win/maple_upload.bat
@@ -5,6 +5,7 @@ set driverLetter=%~dp0
 set driverLetter=%driverLetter:~0,2%
 %driverLetter%
 cd %~dp0
+if exist "C:\Program Files (x86)\Arduino\java\bin" set PATH=C:\Program Files (x86)\Arduino\java\bin;%PATH%
 java -jar maple_loader.jar %1 %2 %3 %4 %5 %6 %7 %8 %9
 
 for /l %%x in (1, 1, 40) do (

--- a/win/maple_upload.bat
+++ b/win/maple_upload.bat
@@ -5,8 +5,8 @@ set driverLetter=%~dp0
 set driverLetter=%driverLetter:~0,2%
 %driverLetter%
 cd %~dp0
-if exist "C:\Program Files (x86)\Arduino\java\bin" set PATH=C:\Program Files (x86)\Arduino\java\bin;%PATH%
-java -jar maple_loader.jar %1 %2 %3 %4 %5 %6 %7 %8 %9
+set PATH=%5\java\bin;%PATH%
+java -jar maple_loader.jar %1 %2 %3 %4
 
 for /l %%x in (1, 1, 40) do (
   ping -w 50 -n 1 192.0.2.1 > nul


### PR DESCRIPTION
This solves the problem where this batch file may use a different Java version compared to the one provided by the Arduino IDE.
(see Issue #67)