### PR TITLE
STM32CubeProg.sh(Erase memory when using DFU)

### DIFF
--- a/stm32CubeProg.sh
+++ b/stm32CubeProg.sh
@@ -129,6 +129,7 @@ case $PROTOCOL in
     ;;
   2)
     PORT="USB1"
+    ERASE="yes"
     shift 3
     ;;
   *)


### PR DESCRIPTION
Programming problems when using DFU.
* When programming with DFU, unable to write non-zero data to already programmed memory.
* Resulting in memory map error, validation error and incorrect data.

Added
* Added: ERASE="yes"
* When DFU is selected