### PR TITLE
Update stm32CubeProg.sh to support J-Link with STM32CubeProgrammer 

### DIFF
--- a/stm32CubeProg.sh
+++ b/stm32CubeProg.sh
@@ -25,7 +25,7 @@ usage() {
   echo "Usage: $(basename "$0") [OPTIONS]...
 
   Mandatory options:
-    -i, --interface <'swd'/'dfu'/'serial'>   interface identifier: 'swd', 'dfu' or 'serial'
+    -i, --interface <'swd'/'dfu'/'serial'/'jlink'>   interface identifier: 'swd', 'dfu', 'serial' or 'jlink'
     -f, --file <path>                        file path to be downloaded: bin or hex
   Optional options:
     -e, --erase                              erase all sectors before flashing
@@ -223,6 +223,9 @@ case "${INTERFACE}" in
       fi
     fi
     ${STM32CP_CLI} --connect port="${PORT}" "${RTS}" "${DTR}" "${ERASE}" --quietMode --download "${FILEPATH}" "${ADDRESS}" --start "${ADDRESS}"
+    ;;
+  jlink)
+    ${STM32CP_CLI} --connect port=JLINK ap=0 "${ERASE}" --quietMode --download "${FILEPATH}" "${ADDRESS}" --start "${ADDRESS}"
     ;;
   *)
     echo "Protocol unknown!" >&2


### PR DESCRIPTION
Summary

This PR implements the support for using a STM32CubeProgrammer with a J-Link from the Arduino IDE, by adding a case to the flashing script. 

Explain the motivation for making this change. What existing problem does the pull request solve?

I have a J-Link probe and can use it directly in STM32CubeProgrammer, but not in the Arduino IDE

Validation

I tested it and it works, doesn't seem to break anything else.

See stm32duino/Arduino_Core_STM32#2452