### PR TITLE
feat(stm32CubeProg): Don’t hardcode Homebrew prefix

### DIFF
--- a/stm32CubeProg.sh
+++ b/stm32CubeProg.sh
@@ -84,11 +84,15 @@ case "${UNAME_OS}" in
     if ! command -v $STM32CP_CLI >/dev/null 2>&1; then
       aborting
     fi
-    if ! command -v $(brew --prefix)/opt/gnu-getopt/bin/getopt >/dev/null 2>&1; then
+    if command -v brew >/dev/null 2>&1 && command -v $(brew --prefix)/opt/gnu-getopt/bin/getopt >/dev/null 2>&1; then
+      export PATH="$(brew --prefix)/opt/gnu-getopt/bin":"$PATH"
+    elif command -v /usr/local/opt/gnu-getopt/bin/getopt >/dev/null 2>&1; then
+      export PATH="/usr/local/opt/gnu-getopt/bin":"$PATH"
+    elif command -v /opt/homebrew/opt/gnu-getopt/bin/getopt >/dev/null 2>&1; then
+      export PATH="/opt/homebrew/opt/gnu-getopt/bin":"$PATH"
+    else
       echo "Warning: long options not supported due to getopt from FreeBSD usage."
       GNU_GETOPT=n
-    else
-      export PATH="$(brew --prefix)/opt/gnu-getopt/bin":"$PATH"
     fi
     ;;
   Windows*)

--- a/stm32CubeProg.sh
+++ b/stm32CubeProg.sh
@@ -84,15 +84,11 @@ case "${UNAME_OS}" in
     if ! command -v $STM32CP_CLI >/dev/null 2>&1; then
       aborting
     fi
-    if ! command -v /usr/local/opt/gnu-getopt/bin/getopt >/dev/null 2>&1; then
-      if ! command -v /opt/homebrew/opt/gnu-getopt/bin/getopt >/dev/null 2>&1; then
-        echo "Warning: long options not supported due to getopt from FreeBSD usage."
-        GNU_GETOPT=n
-      else
-        export PATH="/opt/homebrew/opt/gnu-getopt/bin":"$PATH"
-      fi
+    if ! command -v $(brew --prefix)/opt/gnu-getopt/bin/getopt >/dev/null 2>&1; then
+      echo "Warning: long options not supported due to getopt from FreeBSD usage."
+      GNU_GETOPT=n
     else
-      export PATH="/usr/local/opt/gnu-getopt/bin":"$PATH"
+      export PATH="$(brew --prefix)/opt/gnu-getopt/bin":"$PATH"
     fi
     ;;
   Windows*)


### PR DESCRIPTION
**Summary**

Instead, use `brew --prefix`.

This PR fixes/implements the following **bugs/features**
* [x] Feature: Allows stm32CubeProg.sh to detect gnu-getopt binary/PATH when Homebrew was installed in a non-default prefix.

**Validation**

* Ensure CI build is passed.
* Demonstrate the code is solid.

**Code formatting**

* Ensure AStyle check is passed thanks CI

**Closing issues**

N/A
